### PR TITLE
Fix a few flake8 issues

### DIFF
--- a/config-tests/test_pollbot.py
+++ b/config-tests/test_pollbot.py
@@ -1,5 +1,4 @@
 import requests
-import time
 
 
 def test_product_releases(conf, env):
@@ -45,7 +44,7 @@ def product_version_checks(conf, env, product, channel):
     assert "checks" in data
 
     for check in data["checks"]:
-        #time.sleep(2)
+        # time.sleep(2)
         resp = requests.get(check["url"])
         body = resp.json()
         assert "status" in body

--- a/config-tests/test_server_details.py
+++ b/config-tests/test_server_details.py
@@ -1,4 +1,3 @@
-import pytest
 import requests
 from six import string_types
 


### PR DESCRIPTION

<img width="1298" alt="screen shot 2018-06-07 at 1 06 12 pm" src="https://user-images.githubusercontent.com/387249/41124327-7da70044-6a56-11e8-9fd6-d8f7e4dfd419.png">

@chartjes fixes these; r?:

```
17:52:43 [pollbot.adhoc] Running shell script
17:52:43 + flake8
17:52:44 ./config-tests/test_pollbot.py:2:1: F401 'time' imported but unused
17:52:44 ./config-tests/test_pollbot.py:48:9: E265 block comment should start with '# '
17:52:44 ./config-tests/test_server_details.py:1:1: F401 'pytest' imported but unused
```