### PR TITLE
Add SCM polling and a daily cron, via Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,10 @@ pipeline {
     PROJECT = "${PROJECT ?: JOB_NAME.split('\\.')[0]}"
     TEST_ENV = "${TEST_ENV ?: JOB_NAME.split('\\.')[1]}"
   }
+  triggers {
+    pollSCM('H/5 * * * *')
+    cron('H H * * *')
+  }
   options {
     ansiColor('xterm')
     timestamps()


### PR DESCRIPTION
@chartjes @davehunt r?

Identical to the one in our kinto-integration-tests

Passing ad-hoc here: https://qa-preprod-master.fxtest.jenkins.stage.mozaws.net/job/pollbot.adhoc/5/console